### PR TITLE
add note to install font awesome rails gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Or install it yourself as:
 
     $ gem install active_admin_flat_skin
 
+Install font awesome
+
+```ruby
+gem 'font-awesome-rails'
+```
 
 ## Usage
 


### PR DESCRIPTION
hi @ayann 
active_admin_flat_skin has some dependencies for font-awesome I believe we should give a hint to install font-awesome rails, as I tried multiple gems and this is the one that worked